### PR TITLE
FRMC should now start correctly after first boot

### DIFF
--- a/Companion/Config/ConfigIO.cs
+++ b/Companion/Config/ConfigIO.cs
@@ -9,13 +9,13 @@ namespace Companion.Config
 {
     static class ConfigIO
     {
-        public static async Task<ConfigFile> ReadCompanionConfigFile(string path)
+        public static ConfigFile ReadCompanionConfigFile(string path)
         {
             if(!File.Exists(path)){
                 return new ConfigFile();
             }
 
-            string fileText = await File.ReadAllTextAsync(path);
+            string fileText = File.ReadAllText(path);
             return JsonSerializer.Deserialize<ConfigFile>(fileText);
         }
 

--- a/Companion/Config/ConfigWindow.xaml.cs
+++ b/Companion/Config/ConfigWindow.xaml.cs
@@ -24,9 +24,7 @@ namespace Companion.Config
         {
             InitializeComponent();
 
-            Task<ConfigFile> t = ConfigIO.ReadCompanionConfigFile(Paths.ConfigFile);
-            t.Wait();
-            this.Config = t.Result;
+            this.Config = ConfigIO.ReadCompanionConfigFile(Paths.ConfigFile);
             this.txtSatisfactoryGameDir.Text = this.Config.SatisfactoryGameDirectory;
         }
 
@@ -48,7 +46,7 @@ namespace Companion.Config
 
         private async void btnOK_Click(object sender, RoutedEventArgs e)
         {
-            ConfigFile cfg = await ConfigIO.ReadCompanionConfigFile(Paths.ConfigFile);
+            ConfigFile cfg = ConfigIO.ReadCompanionConfigFile(Paths.ConfigFile);
             cfg.SatisfactoryGameDirectory = this.txtSatisfactoryGameDir.Text;
 
             if(!cfg.IsValidGamePath())


### PR DESCRIPTION
Asynchronously reading the config file on and after the second boot was causing the program to hang while opening. I'm not sure _why_, but making it a synchronous operation is a decent enough fix and won't really impact anything.