### PR TITLE
Better multiarch support

### DIFF
--- a/Companion/exporter/exporter.go
+++ b/Companion/exporter/exporter.go
@@ -46,7 +46,8 @@ func (e *PrometheusExporter) Start() {
 	go e.powerCollector.Start()
 	go e.buildingCollector.Start()
 	go func() {
-		log.Fatal(e.server.ListenAndServe())
+		e.server.ListenAndServe()
+		log.Println("stopping exporter")
 	}()
 }
 

--- a/Companion/exporter/factory_building_collector.go
+++ b/Companion/exporter/factory_building_collector.go
@@ -26,13 +26,13 @@ func NewFactoryBuildingCollector(ctx context.Context, frmAddress string) *Factor
 }
 
 func (c *FactoryBuildingCollector) Start() {
+	c.Collect()
 	for {
 		select {
 		case <-c.ctx.Done():
 			return
-		default:
+		case <-time.After(5 * time.Second):
 			c.Collect()
-			time.Sleep(5 * time.Second)
 		}
 	}
 }

--- a/Companion/exporter/power_collector.go
+++ b/Companion/exporter/power_collector.go
@@ -77,13 +77,13 @@ func NewPowerCollector(ctx context.Context, frmAddress string) *PowerCollector {
 }
 
 func (c *PowerCollector) Start() {
+	c.Collect()
 	for {
 		select {
 		case <-c.ctx.Done():
 			return
-		default:
+		case <-time.After(5 * time.Second):
 			c.Collect()
-			time.Sleep(5 * time.Second)
 		}
 	}
 }

--- a/Companion/exporter/production_collector.go
+++ b/Companion/exporter/production_collector.go
@@ -93,13 +93,14 @@ func NewProductionCollector(ctx context.Context, frmAddress string) *ProductionC
 }
 
 func (c *ProductionCollector) Start() {
+	c.Collect()
 	for {
 		select {
 		case <-c.ctx.Done():
 			return
-		default:
+
+		case <-time.After(5 * time.Second):
 			c.Collect()
-			time.Sleep(5 * time.Second)
 		}
 	}
 }

--- a/Companion/prometheus/wrapper_other.go
+++ b/Companion/prometheus/wrapper_other.go
@@ -1,11 +1,12 @@
-//go:build linux
+//go:build !windows
+// +build !windows
 
 package prometheus
 
 import (
+	"errors"
 	"os"
 	"os/exec"
-	"errors"
 )
 
 type PrometheusWrapper struct {

--- a/Companion/prometheus/wrapper_windows.go
+++ b/Companion/prometheus/wrapper_windows.go
@@ -1,4 +1,5 @@
 //go:build windows
+// +build windows
 
 package prometheus
 

--- a/Companion/realtime_map/map_server.go
+++ b/Companion/realtime_map/map_server.go
@@ -37,7 +37,8 @@ func NewMapServer() (*MapServer, error) {
 
 func (ms *MapServer) Start() {
 	go func() {
-		log.Fatal(ms.httpServer.ListenAndServe())
+		ms.httpServer.ListenAndServe()
+		log.Println("stopping map server")
 	}()
 }
 

--- a/map/src/index.ts
+++ b/map/src/index.ts
@@ -4,6 +4,7 @@ function init()
 {
     let location = window.location
     let params = new URLSearchParams(location.search);
+    let frmHost = "localhost"
     let frmPort = 8080;
 
     if(params.has("frmport")) {
@@ -12,9 +13,15 @@ function init()
             frmPort = p
         }
     }
+    if(params.has("frmhost")) {
+        let h = params.get("frmhost");
+        if(h != undefined){
+            frmHost = h
+        }
+    }
 
     let map = new GameMap(document.getElementById("map")!);
-    map.plotBuildings(`http://localhost:${frmPort}/getFactory`);
-    map.plotTrains(`http://localhost:${frmPort}/getTrains`);
+    map.plotBuildings(`http://${frmHost}:${frmPort}/getFactory`);
+    map.plotTrains(`http://${frmHost}:${frmPort}/getTrains`);
 }
 init();


### PR DESCRIPTION
Some work at getting remote monitoring to work better in linux/docker so as to be integrated with different environments:
Allow hostname config so companion doesn't need to be run on localhost. Provide sane defaults when not specified.
Handle standard signals sent by linux/docker.

Allow exporter to run without prometheus
Make exporter be able to run without prometheus so the companion can run on non-windows.
Add proper flag parsing to args.
Add configurable hostname for frmhost.

Do not log fatal when shutting servers down. Exits cleanly in non-windows environments.

Use timeout on select gochannels for run loops rather than an explicit sleep. Allows for more responsive shutdowns without waiting 5s.

Add exit for sigterm on linux. Handler for stop command when run standard environments like docker.