### PR TITLE
Add vehicle stats

### DIFF
--- a/Companion/exporter/collector_runner.go
+++ b/Companion/exporter/collector_runner.go
@@ -1,0 +1,47 @@
+package exporter
+
+import (
+	"context"
+	"time"
+)
+
+type CollectorRunner struct {
+	collectors []Collector
+	ctx        context.Context
+	cancel     context.CancelFunc
+}
+
+type Collector interface {
+	Collect()
+}
+
+func NewCollectorRunner(ctx context.Context, collectors ...Collector) *CollectorRunner {
+	ctx, cancel := context.WithCancel(ctx)
+	return &CollectorRunner{
+		ctx:        ctx,
+		cancel:     cancel,
+		collectors: collectors,
+	}
+}
+
+func (c *CollectorRunner) Start() {
+	c.Collect()
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-Clock.After(5 * time.Second):
+			c.Collect()
+		}
+	}
+}
+
+func (c *CollectorRunner) Stop() {
+	c.cancel()
+}
+
+func (c *CollectorRunner) Collect() {
+	for _, collector := range c.collectors {
+		collector.Collect()
+	}
+}

--- a/Companion/exporter/collector_runner_test.go
+++ b/Companion/exporter/collector_runner_test.go
@@ -1,0 +1,60 @@
+package exporter_test
+
+import (
+	"context"
+
+	"github.com/AP-Hunt/FicsitRemoteMonitoringCompanion/m/v2/exporter"
+	"github.com/benbjohnson/clock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"time"
+)
+
+type TestCollector struct {
+	counter int
+}
+
+func NewTestCollector() *TestCollector {
+	return &TestCollector{
+		counter: 0,
+	}
+}
+func (t *TestCollector) Collect() {
+	t.counter = t.counter + 1
+}
+
+var _ = Describe("CollectorRunner", func() {
+	Describe("Basic Functionality", func() {
+		It("runs on init and on each timeout", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			testTime := clock.NewMock()
+			exporter.Clock = testTime
+
+			c1 := NewTestCollector()
+			c2 := NewTestCollector()
+			runner := exporter.NewCollectorRunner(ctx, c1, c2)
+			go runner.Start()
+			testTime.Add(5 * time.Second)
+			testTime.Add(5 * time.Second)
+			testTime.Add(5 * time.Second)
+			cancel()
+			Expect(c1.counter).To(Equal(3))
+			Expect(c2.counter).To(Equal(3))
+		})
+
+		It("does not run after being canceled", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			testTime := clock.NewMock()
+			exporter.Clock = testTime
+
+			c1 := NewTestCollector()
+			runner := exporter.NewCollectorRunner(ctx, c1)
+			go runner.Start()
+			testTime.Add(5 * time.Second)
+			cancel()
+			testTime.Add(5 * time.Second)
+			testTime.Add(5 * time.Second)
+			Expect(c1.counter).To(Equal(1))
+		})
+	})
+})

--- a/Companion/exporter/common.go
+++ b/Companion/exporter/common.go
@@ -1,0 +1,51 @@
+package exporter
+
+import (
+	"encoding/json"
+	"github.com/benbjohnson/clock"
+	"log"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var timeRegex = regexp.MustCompile(`\d\d:\d\d:\d\d`)
+
+var Clock = clock.New()
+
+func parseTimeSeconds(timeStr string) *float64 {
+	match := timeRegex.FindStringSubmatch(timeStr)
+	if len(match) < 1 {
+		return nil
+	}
+	parts := strings.Split(match[0], ":")
+	duration := parts[0] + "h" + parts[1] + "m" + parts[2] + "s"
+	t, _ := time.ParseDuration(duration)
+	seconds := t.Seconds()
+	return &seconds
+}
+
+func parseBool(b bool) float64 {
+	if b {
+		return 1
+	} else {
+		return 0
+	}
+}
+
+func retrieveData(frmAddress string, details any) error {
+	resp, err := http.Get(frmAddress)
+
+	if err != nil {
+		log.Printf("error fetching statistics from FRM: %s\n", err)
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	decoder := json.NewDecoder(resp.Body)
+
+	err = decoder.Decode(&details)
+	return err
+}

--- a/Companion/exporter/drone_station_collector.go
+++ b/Companion/exporter/drone_station_collector.go
@@ -1,0 +1,67 @@
+package exporter
+
+import (
+	"log"
+)
+
+type DroneStationCollector struct {
+	FRMAddress string
+}
+
+type DroneStationDetails struct {
+	Id                     string  `json:"ID"`
+	HomeStation            string  `json:"HomeStation"`
+	PairedStation          string  `json:"PairedStation"`
+	DroneStatus            string  `json:"DroneStatus"`
+	AvgIncRate             float64 `json:"AvgIncRate"`
+	AvgIncStack            float64 `json:"AvgIncStack"`
+	AvgOutRate             float64 `json:"AvgOutRate"`
+	AvgOutStack            float64 `json"AvgOutStack"`
+	AvgRndTrip             string  `json:"AvgRndTrip"`
+	AvgTotalIncRate        float64 `json:"AvgTotalIncRate"`
+	AvgTotalIncStack       float64 `json:"AvgTotalIncStack"`
+	AvgTotalOutRate        float64 `json:"AvgTotalOutRate"`
+	AvgTotalOutStack       float64 `json:"AvgTotalOutStack"`
+	AvgTripIncAmt          float64 `json:"AvgTripIncAmt"`
+	EstRndTrip             string  `json:"EstRndTrip"`
+	EstTotalTransRate      float64 `json:"EstTotalTransRate"`
+	EstTransRate           float64 `json:"EstTransRate"`
+	EstLatestTotalIncStack float64 `json:"EstLatestTotalIncStack"`
+	EstLatestTotalOutStack float64 `json:"EstLatestTotalOutStack"`
+	LatestIncStack         float64 `json:"LatestIncStack"`
+	LatestOutStack         float64 `json:"LatestOutStack"`
+	LatestRndTrip          string  `json:"LatestRndTrip"`
+	LatestTripIncAmt       float64 `json:"LatestTripIncAmt"`
+	LatestTripOutAmt       float64 `json:"LatestTripOutAmt"`
+	MedianRndTrip          string  `json:"MedianRndTrip"`
+	MedianTripIncAmt       float64 `json:"MedianTripIncAmt"`
+	MedianTripOutAmt       float64 `json:"MedianTripOutAmt"`
+	EstBatteryRate         float64 `json:"EstBatteryRate"`
+}
+
+func NewDroneStationCollector(frmAddress string) *DroneStationCollector {
+	return &DroneStationCollector{
+		FRMAddress: frmAddress,
+	}
+}
+
+func (c *DroneStationCollector) Collect() {
+	details := []DroneStationDetails{}
+	err := retrieveData(c.FRMAddress, &details)
+	if err != nil {
+		log.Printf("error reading drone station statistics from FRM: %s\n", err)
+		return
+	}
+	for _, d := range details {
+		id := d.Id
+		home := d.HomeStation
+		paired := d.PairedStation
+
+		DronePortBatteryRate.WithLabelValues(id, home, paired).Set(d.EstBatteryRate)
+
+		roundTrip := parseTimeSeconds(d.LatestRndTrip)
+		if roundTrip != nil {
+			DronePortRndTrip.WithLabelValues(id, home, paired).Set(*roundTrip)
+		}
+	}
+}

--- a/Companion/exporter/drone_station_collector_test.go
+++ b/Companion/exporter/drone_station_collector_test.go
@@ -1,0 +1,56 @@
+package exporter_test
+
+import (
+	"github.com/AP-Hunt/FicsitRemoteMonitoringCompanion/m/v2/exporter"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DroneStationCollector", func() {
+	var collector *exporter.DroneStationCollector
+
+	BeforeEach(func() {
+		FRMServer.Reset()
+		collector = exporter.NewDroneStationCollector("http://localhost:9080/getDroneStation")
+
+		FRMServer.ReturnsDroneStationData([]exporter.DroneStationDetails{
+			{
+				Id:               "1",
+				HomeStation:      "home",
+				PairedStation:    "remote station",
+				DroneStatus:      "EDS_EN_ROUTE",
+				AvgIncRate:       1,
+				AvgOutRate:       1,
+				LatestIncStack:   0.2,
+				LatestOutStack:   0.3,
+				LatestRndTrip:    "00:04:24",
+				LatestTripIncAmt: 82,
+				LatestTripOutAmt: 50,
+				EstBatteryRate:   30,
+			},
+		})
+	})
+
+	AfterEach(func() {
+		collector = nil
+	})
+
+	Describe("Drone metrics collection", func() {
+		It("sets the 'drone_port_battery_rate' metric with the right labels", func() {
+			collector.Collect()
+
+			val, err := gaugeValue(exporter.DronePortBatteryRate, "1", "home", "remote station")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(float64(30)))
+		})
+		It("sets the 'drone_port_round_trip_seconds' metric with the right labels", func() {
+			collector.Collect()
+
+			val, err := gaugeValue(exporter.DronePortRndTrip, "1", "home", "remote station")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(float64(264)))
+		})
+	})
+})

--- a/Companion/exporter/drone_station_metrics.go
+++ b/Companion/exporter/drone_station_metrics.go
@@ -1,0 +1,24 @@
+package exporter
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	DronePortBatteryRate = RegisterNewGaugeVec(prometheus.GaugeOpts{
+		Name: "drone_port_battery_rate",
+		Help: "Rate of batteries used",
+	}, []string{
+		"id",
+		"home_station",
+		"paired_station",
+	})
+	DronePortRndTrip = RegisterNewGaugeVec(prometheus.GaugeOpts{
+		Name: "drone_port_round_trip_seconds",
+		Help: "Recorded drone round trip time in seconds",
+	}, []string{
+		"id",
+		"home_station",
+		"paired_station",
+	})
+)

--- a/Companion/exporter/exporter.go
+++ b/Companion/exporter/exporter.go
@@ -46,7 +46,8 @@ func (e *PrometheusExporter) Start() {
 	go e.powerCollector.Start()
 	go e.buildingCollector.Start()
 	go func() {
-		log.Fatal(e.server.ListenAndServe())
+		e.server.ListenAndServe()
+		log.Println("stopping exporter")
 	}()
 }
 

--- a/Companion/exporter/factory_build_detail.go
+++ b/Companion/exporter/factory_build_detail.go
@@ -13,13 +13,6 @@ type BuildingDetail struct {
 	CircuitID    int          `json:"CircuitID"`
 }
 
-type Location struct {
-	X        float64 `json:"x"`
-	Y        float64 `json:"y"`
-	Z        float64 `json:"z"`
-	Rotation int     `json:"rotation"`
-}
-
 type Production struct {
 	Name        string  `json:"Name"`
 	CurrentProd float64 `json:"CurrentProd"`

--- a/Companion/exporter/factory_building_collector.go
+++ b/Companion/exporter/factory_building_collector.go
@@ -26,13 +26,13 @@ func NewFactoryBuildingCollector(ctx context.Context, frmAddress string) *Factor
 }
 
 func (c *FactoryBuildingCollector) Start() {
+	c.Collect()
 	for {
 		select {
 		case <-c.ctx.Done():
 			return
-		default:
+		case <-time.After(5 * time.Second):
 			c.Collect()
-			time.Sleep(5 * time.Second)
 		}
 	}
 }

--- a/Companion/exporter/factory_building_collector.go
+++ b/Companion/exporter/factory_building_collector.go
@@ -1,60 +1,23 @@
 package exporter
 
 import (
-	"context"
-	"encoding/json"
 	"log"
-	"net/http"
 	"strconv"
-	"time"
 )
 
 type FactoryBuildingCollector struct {
 	FRMAddress string
-	ctx        context.Context
-	cancel     context.CancelFunc
 }
 
-func NewFactoryBuildingCollector(ctx context.Context, frmAddress string) *FactoryBuildingCollector {
-	ctx, cancel := context.WithCancel(ctx)
-
+func NewFactoryBuildingCollector(frmAddress string) *FactoryBuildingCollector {
 	return &FactoryBuildingCollector{
 		FRMAddress: frmAddress,
-		ctx:        ctx,
-		cancel:     cancel,
 	}
-}
-
-func (c *FactoryBuildingCollector) Start() {
-	c.Collect()
-	for {
-		select {
-		case <-c.ctx.Done():
-			return
-		case <-time.After(5 * time.Second):
-			c.Collect()
-		}
-	}
-}
-
-func (c *FactoryBuildingCollector) Stop() {
-	c.cancel()
 }
 
 func (c *FactoryBuildingCollector) Collect() {
-	resp, err := http.Get(c.FRMAddress)
-
-	if err != nil {
-		log.Printf("error fetching factory buildings from FRM: %s\n", err)
-		return
-	}
-
-	defer resp.Body.Close()
-
 	details := []BuildingDetail{}
-	decoder := json.NewDecoder(resp.Body)
-
-	err = decoder.Decode(&details)
+	err := retrieveData(c.FRMAddress, &details)
 	if err != nil {
 		log.Printf("error reading factory buildings from FRM: %s\n", err)
 		return

--- a/Companion/exporter/factory_building_collector_test.go
+++ b/Companion/exporter/factory_building_collector_test.go
@@ -1,8 +1,6 @@
 package exporter_test
 
 import (
-	"context"
-
 	"github.com/AP-Hunt/FicsitRemoteMonitoringCompanion/m/v2/exporter"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,7 +12,7 @@ var _ = Describe("FactoryBuildingCollector", func() {
 
 	BeforeEach(func() {
 		FRMServer.Reset()
-		collector = exporter.NewFactoryBuildingCollector(context.Background(), "http://localhost:9080/getFactory")
+		collector = exporter.NewFactoryBuildingCollector("http://localhost:9080/getFactory")
 
 		FRMServer.ReturnsFactoryBuildings([]exporter.BuildingDetail{
 			{

--- a/Companion/exporter/location.go
+++ b/Companion/exporter/location.go
@@ -1,0 +1,29 @@
+package exporter
+
+import (
+	"math"
+)
+
+type Location struct {
+	X        float64 `json:"x"`
+	Y        float64 `json:"y"`
+	Z        float64 `json:"z"`
+	Rotation int     `json:"rotation"`
+}
+
+// Calculates if a location is nearby another.
+// From observation, 5000 units is "good enough" to be considered nearby.
+func (l *Location) isNearby(other Location) bool {
+	x := l.X - other.X
+	y := l.Y - other.Y
+	z := l.Z - other.Z
+
+	dist := math.Sqrt(math.Pow(x, 2) + math.Pow(y, 2) + math.Pow(z, 2))
+	return dist <= 5000
+}
+
+// Calculates if this location is roughly facing the same way as another
+func (l *Location) isSameDirection(other Location) bool {
+	diff := math.Abs(float64(l.Rotation - other.Rotation))
+	return diff <= 90
+}

--- a/Companion/exporter/metrics.go
+++ b/Companion/exporter/metrics.go
@@ -47,7 +47,6 @@ var (
 		"item_name",
 	})
 
-
 	PowerConsumed = RegisterNewGaugeVec(prometheus.GaugeOpts{
 		Name: "power_consumed",
 		Help: "Power consumed on selected power circuit",
@@ -111,25 +110,3 @@ var (
 		"circuit_id",
 	})
 )
-
-func ReportAllMetrics() []*prometheus.MetricVec {
-	return []*prometheus.MetricVec{
-		ItemProductionCapacityPerMinute.MetricVec,
-		ItemProductionCapacityPercent.MetricVec,
-		ItemConsumptionCapacityPerMinute.MetricVec,
-		ItemConsumptionCapacityPercent.MetricVec,
-		ItemsProducedPerMin.MetricVec,
-		ItemsConsumedPerMin.MetricVec,
-		MachineItemsProducedPerMin.MetricVec,
-		MachineItemsProducedEffiency.MetricVec,
-		PowerConsumed.MetricVec,
-		PowerCapacity.MetricVec,
-		PowerMaxConsumed.MetricVec,
-		BatteryDifferential.MetricVec,
-		BatteryPercent.MetricVec,
-		BatteryCapacity.MetricVec,
-		BatterySecondsEmpty.MetricVec,
-		BatterySecondsFull.MetricVec,
-		FuseTriggered.MetricVec,
-	}
-}

--- a/Companion/exporter/power_collector.go
+++ b/Companion/exporter/power_collector.go
@@ -1,23 +1,13 @@
 package exporter
 
 import (
-	"context"
-	"encoding/json"
 	"log"
-	"net/http"
-	"regexp"
-	"strings"
 	"strconv"
-	"time"
 )
 
 type PowerCollector struct {
 	FRMAddress string
-	ctx        context.Context
-	cancel     context.CancelFunc
 }
-
-var timeRegex = regexp.MustCompile(`\d\d:\d\d:\d\d`)
 
 type PowerDetails struct {
 	CircuitId           float64 `json:"CircuitID"`
@@ -32,80 +22,15 @@ type PowerDetails struct {
 	FuseTriggered       bool    `json:"FuseTriggered"`
 }
 
-func parseTimeSeconds(timeStr string) (bool, float64) {
-	match := timeRegex.FindStringSubmatch(timeStr)
-	if len(match) < 1 {
-		return false, 0
-	}
-	parts := strings.Split(match[0], ":")
-	duration := parts[0] + "h" + parts[1] + "m" + parts[2] + "s"
-	t, _ := time.ParseDuration(duration)
-	return true, t.Seconds()
-}
-
-func (pd *PowerDetails) parseBatteryTimeEmptySeconds() *float64 {
-	matched, params := parseTimeSeconds(pd.BatteryTimeEmpty)
-	if !matched {
-		return nil
-	}
-	return &params
-}
-
-func (pd *PowerDetails) parseBatteryTimeFullSeconds() *float64 {
-	matched, params := parseTimeSeconds(pd.BatteryTimeFull)
-	if !matched {
-		return nil
-	}
-	return &params
-}
-
-func (pd *PowerDetails) parseFuseTriggered() float64 {
-	if pd.FuseTriggered {
-		return 1
-	} else {
-		return 0
-	}
-}
-
-func NewPowerCollector(ctx context.Context, frmAddress string) *PowerCollector {
-	ctx, cancel := context.WithCancel(ctx)
+func NewPowerCollector(frmAddress string) *PowerCollector {
 	return &PowerCollector{
 		FRMAddress: frmAddress,
-		ctx:        ctx,
-		cancel:     cancel,
 	}
-}
-
-func (c *PowerCollector) Start() {
-	c.Collect()
-	for {
-		select {
-		case <-c.ctx.Done():
-			return
-		case <-time.After(5 * time.Second):
-			c.Collect()
-		}
-	}
-}
-
-func (c *PowerCollector) Stop() {
-	c.cancel()
 }
 
 func (c *PowerCollector) Collect() {
-	resp, err := http.Get(c.FRMAddress)
-
-	if err != nil {
-		log.Printf("error fetching power statistics from FRM: %s\n", err)
-		return
-	}
-
-	defer resp.Body.Close()
-
 	details := []PowerDetails{}
-	decoder := json.NewDecoder(resp.Body)
-
-	err = decoder.Decode(&details)
+	err := retrieveData(c.FRMAddress, &details)
 	if err != nil {
 		log.Printf("error reading power statistics from FRM: %s\n", err)
 		return
@@ -119,15 +44,15 @@ func (c *PowerCollector) Collect() {
 		BatteryDifferential.WithLabelValues(circuitId).Set(d.BatteryDifferential)
 		BatteryPercent.WithLabelValues(circuitId).Set(d.BatteryPercent)
 		BatteryCapacity.WithLabelValues(circuitId).Set(d.BatteryCapacity)
-		batterySecondsRemaining := d.parseBatteryTimeEmptySeconds()
+		batterySecondsRemaining := parseTimeSeconds(d.BatteryTimeEmpty)
 		if batterySecondsRemaining != nil {
 			BatterySecondsEmpty.WithLabelValues(circuitId).Set(*batterySecondsRemaining)
 		}
-		batterySecondsFull := d.parseBatteryTimeFullSeconds()
+		batterySecondsFull := parseTimeSeconds(d.BatteryTimeFull)
 		if batterySecondsFull != nil {
 			BatterySecondsFull.WithLabelValues(circuitId).Set(*batterySecondsFull)
 		}
-		fuseTriggered := d.parseFuseTriggered()
+		fuseTriggered := parseBool(d.FuseTriggered)
 		FuseTriggered.WithLabelValues(circuitId).Set(fuseTriggered)
 	}
 }

--- a/Companion/exporter/power_collector.go
+++ b/Companion/exporter/power_collector.go
@@ -77,13 +77,13 @@ func NewPowerCollector(ctx context.Context, frmAddress string) *PowerCollector {
 }
 
 func (c *PowerCollector) Start() {
+	c.Collect()
 	for {
 		select {
 		case <-c.ctx.Done():
 			return
-		default:
+		case <-time.After(5 * time.Second):
 			c.Collect()
-			time.Sleep(5 * time.Second)
 		}
 	}
 }

--- a/Companion/exporter/power_collector_test.go
+++ b/Companion/exporter/power_collector_test.go
@@ -1,8 +1,6 @@
 package exporter_test
 
 import (
-	"context"
-
 	"github.com/AP-Hunt/FicsitRemoteMonitoringCompanion/m/v2/exporter"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -13,32 +11,32 @@ var _ = Describe("PowerCollector", func() {
 
 	BeforeEach(func() {
 		FRMServer.Reset()
-		collector = exporter.NewPowerCollector(context.Background(), "http://localhost:9080/getPower")
+		collector = exporter.NewPowerCollector("http://localhost:9080/getPower")
 
 		FRMServer.ReturnsPowerData([]exporter.PowerDetails{
 			{
-				CircuitId: 1,
-				PowerConsumed: 30,
-				PowerCapacity: 44,
-				PowerMaxConsumed: 50,
+				CircuitId:           1,
+				PowerConsumed:       30,
+				PowerCapacity:       44,
+				PowerMaxConsumed:    50,
 				BatteryDifferential: 12,
-				BatteryPercent: 60,
-				BatteryCapacity: 100,
-				BatteryTimeEmpty: "00:00:00",
-				BatteryTimeFull: "33:22:11",
-				FuseTriggered: false,
+				BatteryPercent:      60,
+				BatteryCapacity:     100,
+				BatteryTimeEmpty:    "00:00:00",
+				BatteryTimeFull:     "33:22:11",
+				FuseTriggered:       false,
 			},
 			{
-				CircuitId: 2,
-				PowerConsumed: 55,
-				PowerCapacity: 44,
-				PowerMaxConsumed: 60,
+				CircuitId:           2,
+				PowerConsumed:       55,
+				PowerCapacity:       44,
+				PowerMaxConsumed:    60,
 				BatteryDifferential: -12,
-				BatteryPercent: 60,
-				BatteryCapacity: 100,
-				BatteryTimeEmpty: "00:3:00",
-				BatteryTimeFull: "00:00:00",
-				FuseTriggered: true,
+				BatteryPercent:      60,
+				BatteryCapacity:     100,
+				BatteryTimeEmpty:    "00:3:00",
+				BatteryTimeFull:     "00:00:00",
+				FuseTriggered:       true,
 			},
 		})
 	})

--- a/Companion/exporter/production_collector.go
+++ b/Companion/exporter/production_collector.go
@@ -93,13 +93,14 @@ func NewProductionCollector(ctx context.Context, frmAddress string) *ProductionC
 }
 
 func (c *ProductionCollector) Start() {
+	c.Collect()
 	for {
 		select {
 		case <-c.ctx.Done():
 			return
-		default:
+
+		case <-time.After(5 * time.Second):
 			c.Collect()
-			time.Sleep(5 * time.Second)
 		}
 	}
 }

--- a/Companion/exporter/production_collector.go
+++ b/Companion/exporter/production_collector.go
@@ -1,19 +1,13 @@
 package exporter
 
 import (
-	"context"
-	"encoding/json"
 	"log"
-	"net/http"
 	"regexp"
 	"strconv"
-	"time"
 )
 
 type ProductionCollector struct {
 	FRMAddress string
-	ctx        context.Context
-	cancel     context.CancelFunc
 }
 
 var prodPerMinRegex = regexp.MustCompile(`P: (?P<prod_current>[\d.]+)/(?P<prod_capacity>[\d.]+)/min - C: (?P<cons_current>[\d.]+)/(?P<cons_capacity>[\d.]+)/min`)
@@ -82,47 +76,15 @@ func (pd *ProductionDetails) ItemConsumptionCapacity() *float64 {
 	return &v
 }
 
-func NewProductionCollector(ctx context.Context, frmAddress string) *ProductionCollector {
-	ctx, cancel := context.WithCancel(ctx)
-
+func NewProductionCollector(frmAddress string) *ProductionCollector {
 	return &ProductionCollector{
 		FRMAddress: frmAddress,
-		ctx:        ctx,
-		cancel:     cancel,
 	}
-}
-
-func (c *ProductionCollector) Start() {
-	c.Collect()
-	for {
-		select {
-		case <-c.ctx.Done():
-			return
-
-		case <-time.After(5 * time.Second):
-			c.Collect()
-		}
-	}
-}
-
-func (c *ProductionCollector) Stop() {
-	c.cancel()
 }
 
 func (c *ProductionCollector) Collect() {
-	resp, err := http.Get(c.FRMAddress)
-
-	if err != nil {
-		log.Printf("error fetching production statistics from FRM: %s\n", err)
-		return
-	}
-
-	defer resp.Body.Close()
-
 	details := []ProductionDetails{}
-	decoder := json.NewDecoder(resp.Body)
-
-	err = decoder.Decode(&details)
+	err := retrieveData(c.FRMAddress, &details)
 	if err != nil {
 		log.Printf("error reading production statistics from FRM: %s\n", err)
 		return

--- a/Companion/exporter/production_collector_test.go
+++ b/Companion/exporter/production_collector_test.go
@@ -1,7 +1,6 @@
 package exporter_test
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/AP-Hunt/FicsitRemoteMonitoringCompanion/m/v2/exporter"
@@ -23,7 +22,7 @@ var _ = Describe("ProductionCollector", func() {
 
 	BeforeEach(func() {
 		FRMServer.Reset()
-		collector = exporter.NewProductionCollector(context.Background(), "http://localhost:9080/getProdStats")
+		collector = exporter.NewProductionCollector("http://localhost:9080/getProdStats")
 
 		FRMServer.ReturnsProductionData([]exporter.ProductionDetails{
 			{

--- a/Companion/exporter/registration.go
+++ b/Companion/exporter/registration.go
@@ -12,6 +12,7 @@ type MetricVectorDetails struct {
 }
 
 var RegisteredMetricVectors = []MetricVectorDetails{}
+var RegisteredMetrics = []*prometheus.GaugeVec{}
 
 func RegisterNewGaugeVec(opts prometheus.GaugeOpts, labelNames []string) *prometheus.GaugeVec {
 	RegisteredMetricVectors = append(RegisteredMetricVectors, MetricVectorDetails{
@@ -20,5 +21,7 @@ func RegisterNewGaugeVec(opts prometheus.GaugeOpts, labelNames []string) *promet
 		Labels: labelNames,
 	})
 
-	return promauto.NewGaugeVec(opts, labelNames)
+	metric := promauto.NewGaugeVec(opts, labelNames)
+	RegisteredMetrics = append(RegisteredMetrics, metric)
+	return metric
 }

--- a/Companion/exporter/train_collector.go
+++ b/Companion/exporter/train_collector.go
@@ -1,0 +1,115 @@
+package exporter
+
+import (
+	"log"
+	"time"
+)
+
+type TrainCollector struct {
+	FRMAddress    string
+	TrackedTrains map[string]*TrainDetails
+}
+
+type TimeTable struct {
+	StationName string `json:"StationName"`
+}
+type TrainDetails struct {
+	TrainName        string      `json:"TrainName"`
+	PowerConsumed    float64     `json:"PowerConsumed"`
+	TrainStation     string      `json:"TrainStation"`
+	Derailed         bool        `json:"Derailed"`
+	Status           string      `json:"Status"` //"TS_SelfDriving",
+	TimeTable        []TimeTable `json:"TimeTable"`
+	ArrivalTime      time.Time
+	StationCounter   int
+	FirstArrivalTime time.Time
+}
+
+func NewTrainCollector(frmAddress string) *TrainCollector {
+	return &TrainCollector{
+		FRMAddress:    frmAddress,
+		TrackedTrains: make(map[string]*TrainDetails),
+	}
+}
+
+func (t *TrainDetails) recordRoundTripTime(now time.Time) {
+	if len(t.TimeTable) <= t.StationCounter {
+		roundTripSeconds := now.Sub(t.FirstArrivalTime).Seconds()
+		TrainRoundTrip.WithLabelValues(t.TrainName).Set(roundTripSeconds)
+		t.StationCounter = 0
+		t.FirstArrivalTime = now
+	}
+}
+
+func (t *TrainDetails) recordSegmentTripTime(destination string, now time.Time) {
+	tripSeconds := now.Sub(t.ArrivalTime).Seconds()
+	TrainSegmentTrip.WithLabelValues(t.TrainName, t.TrainStation, destination).Set(tripSeconds)
+}
+
+func (t *TrainDetails) recordNextStation(d *TrainDetails) {
+	if t.TrainStation != d.TrainStation {
+		t.StationCounter = t.StationCounter + 1
+		now := Clock.Now()
+		t.recordSegmentTripTime(d.TrainStation, now)
+		t.recordRoundTripTime(now)
+		t.ArrivalTime = now
+		t.TrainStation = d.TrainStation
+	}
+}
+
+func (t *TrainDetails) markFirstStation(d *TrainDetails) {
+	if t.TrainStation != d.TrainStation {
+		t.StationCounter = 0
+		t.FirstArrivalTime = Clock.Now()
+		t.ArrivalTime = Clock.Now()
+		t.TrainStation = d.TrainStation
+	}
+}
+
+func (t *TrainDetails) startTracking(trackedTrains map[string]*TrainDetails) {
+	trackedTrain := TrainDetails{
+		TrainName:      t.TrainName,
+		TrainStation:   t.TrainStation,
+		StationCounter: 0,
+		TimeTable:      t.TimeTable,
+	}
+	trackedTrains[t.TrainName] = &trackedTrain
+}
+
+func (d *TrainDetails) handleTimingUpdates(trackedTrains map[string]*TrainDetails) {
+	// track self driving train timing
+	if d.Status == "TS_SelfDriving" {
+		train, exists := trackedTrains[d.TrainName]
+		if exists && !train.FirstArrivalTime.IsZero() {
+			train.recordNextStation(d)
+		} else if exists {
+			train.markFirstStation(d)
+		} else {
+			d.startTracking(trackedTrains)
+		}
+	} else {
+		//remove manual trains, nothing to mark
+		_, exists := trackedTrains[d.TrainName]
+		if exists {
+			delete(trackedTrains, d.TrainName)
+		}
+	}
+}
+
+func (c *TrainCollector) Collect() {
+	details := []TrainDetails{}
+	err := retrieveData(c.FRMAddress, &details)
+	if err != nil {
+		log.Printf("error reading train statistics from FRM: %s\n", err)
+		return
+	}
+
+	for _, d := range details {
+		TrainPower.WithLabelValues(d.TrainName).Set(d.PowerConsumed)
+
+		isDerailed := parseBool(d.Derailed)
+		TrainDerailed.WithLabelValues(d.TrainName).Set(isDerailed)
+
+		d.handleTimingUpdates(c.TrackedTrains)
+	}
+}

--- a/Companion/exporter/train_collector_test.go
+++ b/Companion/exporter/train_collector_test.go
@@ -1,0 +1,190 @@
+package exporter_test
+
+import (
+	"github.com/AP-Hunt/FicsitRemoteMonitoringCompanion/m/v2/exporter"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/benbjohnson/clock"
+	"time"
+)
+
+func updateTrain(station string) {
+	FRMServer.ReturnsTrainData([]exporter.TrainDetails{
+		{
+			TrainName:     "Train1",
+			PowerConsumed: 0,
+			TrainStation:  station,
+			Derailed:      false,
+			Status:        "TS_SelfDriving",
+			TimeTable: []exporter.TimeTable{
+				{StationName: "First"},
+				{StationName: "Second"},
+				{StationName: "Third"},
+			},
+		},
+		{
+			TrainName:     "Not In Use",
+			PowerConsumed: 0,
+			TrainStation:  "Offsite",
+			Derailed:      false,
+			Status:        "TS_Parked",
+			TimeTable: []exporter.TimeTable{
+				{StationName: "Offsite"},
+			},
+		},
+	})
+}
+
+var _ = Describe("TrainCollector", func() {
+	var collector *exporter.TrainCollector
+
+	BeforeEach(func() {
+		FRMServer.Reset()
+		collector = exporter.NewTrainCollector("http://localhost:9080/getTrains")
+
+		FRMServer.ReturnsTrainData([]exporter.TrainDetails{
+			{
+				TrainName:     "Train1",
+				PowerConsumed: 67,
+				TrainStation:  "NextStation",
+				Derailed:      false,
+				Status:        "TS_SelfDriving",
+				TimeTable: []exporter.TimeTable{
+					{StationName: "First"},
+					{StationName: "Second"},
+				},
+			},
+			{
+				TrainName:     "DerailedTrain",
+				PowerConsumed: 0,
+				TrainStation:  "NextStation",
+				Derailed:      true,
+				Status:        "Derailed",
+			},
+		})
+	})
+
+	AfterEach(func() {
+		collector = nil
+	})
+
+	Describe("Train metrics collection", func() {
+		It("sets the 'train_derailed' metric with the right labels", func() {
+			collector.Collect()
+
+			val, err := gaugeValue(exporter.TrainDerailed, "DerailedTrain")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(float64(1)))
+		})
+
+		It("sets the 'train_power_consumed' metric with the right labels", func() {
+			collector.Collect()
+
+			val, err := gaugeValue(exporter.TrainPower, "Train1")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(float64(67)))
+		})
+
+		It("sets 'train_segment_trip_seconds' metric with the right labels", func() {
+
+			testTime := clock.NewMock()
+			exporter.Clock = testTime
+			updateTrain("First")
+
+			collector.Collect()
+			val, err := gaugeValue(exporter.TrainSegmentTrip, "Train1", "First", "Second")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(float64(0)))
+			testTime.Add(5 * time.Second)
+			collector.Collect()
+			val, err = gaugeValue(exporter.TrainSegmentTrip, "Train1", "First", "Second")
+			Expect(val).To(Equal(float64(0)))
+			testTime.Add(25 * time.Second)
+
+			// Start timing the trains here - No metrics yet because we just got our first "start" marker from the station change.
+			updateTrain("Second")
+			collector.Collect()
+			val, err = gaugeValue(exporter.TrainSegmentTrip, "Train1", "First", "Second")
+			Expect(val).To(Equal(float64(0)))
+
+			testTime.Add(15 * time.Second)
+			collector.Collect()
+			testTime.Add(10 * time.Second)
+			collector.Collect()
+			// No stats again since train is still "en route"
+			val, err = gaugeValue(exporter.TrainSegmentTrip, "Train1", "First", "Second")
+			Expect(val).To(Equal(float64(0)))
+
+			testTime.Add(5 * time.Second)
+
+			// Can record elapsed time between Second and Third stations
+			updateTrain("Third")
+			collector.Collect()
+			val, err = gaugeValue(exporter.TrainSegmentTrip, "Train1", "Second", "Third")
+			Expect(val).To(Equal(float64(30)))
+
+			testTime.Add(30 * time.Second)
+			updateTrain("First")
+			collector.Collect()
+			val, err = gaugeValue(exporter.TrainSegmentTrip, "Train1", "Third", "First")
+			Expect(val).To(Equal(float64(30)))
+
+			testTime.Add(30 * time.Second)
+			updateTrain("Second")
+			collector.Collect()
+
+			val, err = gaugeValue(exporter.TrainSegmentTrip, "Train1", "First", "Second")
+			Expect(val).To(Equal(float64(30)))
+
+		})
+
+		It("sets 'train_round_trip_seconds' metric with the right labels", func() {
+			testTime := clock.NewMock()
+			exporter.Clock = testTime
+			updateTrain("Third")
+
+			collector.Collect()
+			val, err := gaugeValue(exporter.TrainRoundTrip, "Train1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(float64(0)))
+			testTime.Add(30 * time.Second)
+
+			// Started recording round trip on first station arrival
+			updateTrain("First")
+			collector.Collect()
+			val, err = gaugeValue(exporter.TrainRoundTrip, "Train1")
+			Expect(val).To(Equal(float64(0)))
+
+			testTime.Add(30 * time.Second)
+			updateTrain("Second")
+			collector.Collect()
+			testTime.Add(30 * time.Second)
+			updateTrain("Third")
+			collector.Collect()
+			testTime.Add(30 * time.Second)
+			updateTrain("First")
+			collector.Collect()
+
+			val, err = gaugeValue(exporter.TrainRoundTrip, "Train1")
+			Expect(val).To(Equal(float64(90)))
+
+			//second round trip should also record properly
+			testTime.Add(10 * time.Second)
+			updateTrain("Second")
+			collector.Collect()
+			testTime.Add(10 * time.Second)
+			updateTrain("Third")
+			collector.Collect()
+			testTime.Add(10 * time.Second)
+			updateTrain("First")
+			collector.Collect()
+
+			val, err = gaugeValue(exporter.TrainRoundTrip, "Train1")
+			Expect(val).To(Equal(float64(30)))
+
+		})
+	})
+})

--- a/Companion/exporter/train_metrics.go
+++ b/Companion/exporter/train_metrics.go
@@ -1,0 +1,34 @@
+package exporter
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	TrainRoundTrip = RegisterNewGaugeVec(prometheus.GaugeOpts{
+		Name: "train_round_trip_seconds",
+		Help: "Recorded train round trip time in seconds",
+	}, []string{
+		"name",
+	})
+	TrainSegmentTrip = RegisterNewGaugeVec(prometheus.GaugeOpts{
+		Name: "train_segment_trip_seconds",
+		Help: "Recorded train trip between two stations",
+	}, []string{
+		"name",
+		"from",
+		"to",
+	})
+	TrainDerailed = RegisterNewGaugeVec(prometheus.GaugeOpts{
+		Name: "train_derailed",
+		Help: "Is train derailed",
+	}, []string{
+		"name",
+	})
+	TrainPower = RegisterNewGaugeVec(prometheus.GaugeOpts{
+		Name: "train_power_consumed",
+		Help: "How much power train is consuming",
+	}, []string{
+		"name",
+	})
+)

--- a/Companion/exporter/vehicle_collector.go
+++ b/Companion/exporter/vehicle_collector.go
@@ -1,0 +1,98 @@
+package exporter
+
+import (
+	"log"
+	"time"
+)
+
+type VehicleCollector struct {
+	FRMAddress      string
+	TrackedVehicles map[string]*VehicleDetails
+}
+
+type VehicleDetails struct {
+	Id            string   `json:"ID"`
+	VehicleType   string   `json:"VehicleType"`
+	Location      Location `json:"location"`
+	ForwardSpeed  float64  `json:"ForwardSpeed"`
+	AutoPilot     bool     `json:"AutoPilot"`
+	FuelType      string   `json:"FuelType"`
+	FuelInventory float64  `json"FuelInventory"`
+	PathName      string   `json:"PathName"`
+	DepartTime    time.Time
+	Departed      bool
+}
+
+func (v *VehicleDetails) recordElapsedTime() {
+	now := Clock.Now()
+	tripSeconds := now.Sub(v.DepartTime).Seconds()
+	VehicleRoundTrip.WithLabelValues(v.Id, v.VehicleType, v.PathName).Set(tripSeconds)
+	v.Departed = false
+}
+
+func (v *VehicleDetails) isCompletingTrip(updatedLocation Location) bool {
+	// vehicle near first tracked location facing roughly the same way
+	return v.Departed && v.Location.isNearby(updatedLocation) && v.Location.isSameDirection(updatedLocation)
+}
+
+func (v *VehicleDetails) isStartingTrip(updatedLocation Location) bool {
+	// vehicle departed from first tracked location
+	return !v.Departed && !v.Location.isNearby(updatedLocation)
+}
+
+func (v *VehicleDetails) startTracking(trackedVehicles map[string]*VehicleDetails) {
+	// Only start tracking the vehicle at low speeds so it's
+	// likely at a station or somewhere easier to track.
+	if v.ForwardSpeed < 10 {
+		trackedVehicle := VehicleDetails{
+			Id:          v.Id,
+			Location:    v.Location,
+			VehicleType: v.VehicleType,
+			PathName:    v.PathName,
+			Departed:    false,
+		}
+		trackedVehicles[v.Id] = &trackedVehicle
+	}
+}
+
+func (d *VehicleDetails) handleTimingUpdates(trackedVehicles map[string]*VehicleDetails) {
+	if d.AutoPilot {
+		vehicle, exists := trackedVehicles[d.Id]
+		if exists && vehicle.isCompletingTrip(d.Location) {
+			vehicle.recordElapsedTime()
+		} else if exists && vehicle.isStartingTrip(d.Location) {
+			vehicle.Departed = true
+			vehicle.DepartTime = Clock.Now()
+		} else if !exists {
+			d.startTracking(trackedVehicles)
+		}
+	} else {
+		//remove manual vehicles, nothing to mark
+		_, exists := trackedVehicles[d.Id]
+		if exists {
+			delete(trackedVehicles, d.Id)
+		}
+	}
+}
+
+func NewVehicleCollector(frmAddress string) *VehicleCollector {
+	return &VehicleCollector{
+		FRMAddress:      frmAddress,
+		TrackedVehicles: make(map[string]*VehicleDetails),
+	}
+}
+
+func (c *VehicleCollector) Collect() {
+	details := []VehicleDetails{}
+	err := retrieveData(c.FRMAddress, &details)
+	if err != nil {
+		log.Printf("error reading vehicle statistics from FRM: %s\n", err)
+		return
+	}
+
+	for _, d := range details {
+		VehicleFuel.WithLabelValues(d.Id, d.VehicleType, d.FuelType).Set(d.FuelInventory)
+
+		d.handleTimingUpdates(c.TrackedVehicles)
+	}
+}

--- a/Companion/exporter/vehicle_collector_test.go
+++ b/Companion/exporter/vehicle_collector_test.go
@@ -1,0 +1,130 @@
+package exporter_test
+
+import (
+	"github.com/AP-Hunt/FicsitRemoteMonitoringCompanion/m/v2/exporter"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/benbjohnson/clock"
+	"time"
+)
+
+func updateLocation(x float64, y float64, rotation int) {
+	FRMServer.ReturnsVehicleData([]exporter.VehicleDetails{
+		{
+			Id:           "1",
+			VehicleType:  "Truck",
+			ForwardSpeed: 0,
+			Location: exporter.Location{
+				X:        x,
+				Y:        y,
+				Z:        0,
+				Rotation: rotation,
+			},
+			AutoPilot:     true,
+			FuelType:      "Coal",
+			FuelInventory: 23,
+			PathName:      "Path",
+		},
+		{
+			Id:           "2",
+			VehicleType:  "Truck",
+			ForwardSpeed: 0,
+			Location: exporter.Location{
+				X:        0,
+				Y:        0,
+				Z:        0,
+				Rotation: rotation,
+			},
+			AutoPilot:     false,
+			FuelType:      "Coal",
+			FuelInventory: 23,
+			PathName:      "no path",
+		},
+	})
+}
+
+var _ = Describe("VehicleCollector", func() {
+	var collector *exporter.VehicleCollector
+
+	BeforeEach(func() {
+		FRMServer.Reset()
+		collector = exporter.NewVehicleCollector("http://localhost:9080/getVehicles")
+
+		FRMServer.ReturnsVehicleData([]exporter.VehicleDetails{
+			{
+				Id:           "1",
+				VehicleType:  "Truck",
+				ForwardSpeed: 80,
+				Location: exporter.Location{
+					X:        1000,
+					Y:        2000,
+					Z:        1000,
+					Rotation: 60,
+				},
+				AutoPilot:     true,
+				FuelType:      "Coal",
+				FuelInventory: 23,
+				PathName:      "Path",
+			},
+		})
+	})
+
+	AfterEach(func() {
+		collector = nil
+	})
+
+	Describe("Vehicle metrics collection", func() {
+		It("sets the 'vehicle_fuel' metric with the right labels", func() {
+			collector.Collect()
+
+			val, err := gaugeValue(exporter.VehicleFuel, "1", "Truck", "Coal")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(float64(23)))
+		})
+
+		It("sets the 'vehicle_round_trip_seconds' metric with the right labels", func() {
+
+			testTime := clock.NewMock()
+			exporter.Clock = testTime
+			// truck will be too fast here, nothing recorded
+			collector.Collect()
+			val, err := gaugeValue(exporter.VehicleRoundTrip, "1", "Truck", "Path")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(float64(0)))
+
+			testTime.Add(30 * time.Second)
+			updateLocation(0, 0, 0)
+			// first time collecting stats, nothing yet but it does set start location to 0,0,0
+			collector.Collect()
+			val, err = gaugeValue(exporter.VehicleRoundTrip, "1", "Truck", "Path")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(float64(0)))
+
+			testTime.Add(30 * time.Second)
+			updateLocation(8000, 2000, 0)
+			//go to a far away location now, star the timer
+			collector.Collect()
+			val, err = gaugeValue(exporter.VehicleRoundTrip, "1", "Truck", "Path")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(float64(0)))
+
+			testTime.Add(10 * time.Second)
+			updateLocation(1000, 2000, 180)
+			//We are near but not facing the right way. Do not record this until we face near the right direction
+			collector.Collect()
+			val, err = gaugeValue(exporter.VehicleRoundTrip, "1", "Truck", "Path")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(float64(0)))
+
+			testTime.Add(20 * time.Second)
+			updateLocation(1000, 2000, 0)
+			//Now we are back near enough to where we began recording, and facing near the same way end recording
+			collector.Collect()
+			val, err = gaugeValue(exporter.VehicleRoundTrip, "1", "Truck", "Path")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(float64(30)))
+		})
+	})
+})

--- a/Companion/exporter/vehicle_metrics.go
+++ b/Companion/exporter/vehicle_metrics.go
@@ -1,0 +1,24 @@
+package exporter
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	VehicleRoundTrip = RegisterNewGaugeVec(prometheus.GaugeOpts{
+		Name: "vehicle_round_trip_seconds",
+		Help: "Recorded vehicle round trip time in seconds",
+	}, []string{
+		"id",
+		"vehicle_type",
+		"path_name",
+	})
+	VehicleFuel = RegisterNewGaugeVec(prometheus.GaugeOpts{
+		Name: "vehicle_fuel",
+		Help: "Amount of fuel remaining",
+	}, []string{
+		"id",
+		"vehicle_type",
+		"fuel_type",
+	})
+)

--- a/Companion/exporter/vhicle_collector_test.go
+++ b/Companion/exporter/vhicle_collector_test.go
@@ -1,0 +1,1 @@
+package exporter_test

--- a/Companion/exporter/vhicle_collector_test.go
+++ b/Companion/exporter/vhicle_collector_test.go
@@ -1,1 +1,0 @@
-package exporter_test

--- a/Companion/go.mod
+++ b/Companion/go.mod
@@ -1,6 +1,6 @@
 module github.com/AP-Hunt/FicsitRemoteMonitoringCompanion/m/v2
 
-go 1.17
+go 1.18
 
 require (
 	github.com/onsi/ginkgo/v2 v2.0.0
@@ -10,6 +10,7 @@ require (
 )
 
 require (
+	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/Companion/go.sum
+++ b/Companion/go.sum
@@ -4,6 +4,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/Companion/main.go
+++ b/Companion/main.go
@@ -9,7 +9,6 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"syscall"

--- a/Companion/main.go
+++ b/Companion/main.go
@@ -49,7 +49,7 @@ func main() {
 	promExporter := exporter.NewPrometheusExporter("http://" + frmHostname + ":" + strconv.Itoa(frmPort))
 
 	var prom *prometheus.PrometheusWrapper
-	if runtime.GOOS == "windows" && !noProm {
+	if !noProm {
 		// Create prometheus
 		prom, err = prometheus.NewPrometheusWrapper()
 		if err != nil {
@@ -66,7 +66,7 @@ func main() {
 	}
 
 	// Start prometheus
-	if runtime.GOOS == "windows" && !noProm {
+	if !noProm {
 		err = prom.Start()
 		if err != nil {
 			fmt.Printf("error starting prometheus: %s", err)
@@ -99,12 +99,7 @@ Press Ctrl + C to exit.
 
 	// Wait for an interrupt signal
 	sigChan := make(chan os.Signal, 1)
-	if runtime.GOOS == "windows" {
-		signal.Notify(sigChan, os.Interrupt)
-	} else {
-		signal.Notify(sigChan, syscall.SIGTERM)
-		signal.Notify(sigChan, syscall.SIGINT)
-	}
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	<-sigChan
 
 	// Stop the exporter
@@ -114,7 +109,7 @@ Press Ctrl + C to exit.
 	}
 
 	// Stop prometheus
-	if runtime.GOOS == "windows" && !noProm {
+	if !noProm {
 		err = prom.Stop()
 		if err != nil {
 			fmt.Printf("error stopping prometheus: %s", err)

--- a/Companion/prometheus/wrapper_other.go
+++ b/Companion/prometheus/wrapper_other.go
@@ -1,11 +1,12 @@
-//go:build linux
+//go:build !windows
+// +build !windows
 
 package prometheus
 
 import (
+	"errors"
 	"os"
 	"os/exec"
-	"errors"
 )
 
 type PrometheusWrapper struct {

--- a/Companion/prometheus/wrapper_other.go
+++ b/Companion/prometheus/wrapper_other.go
@@ -4,11 +4,11 @@
 package prometheus
 
 import (
-	"errors"
 	"os"
 	"os/exec"
 )
 
+// a no-op prometheus wrapper. Not implemented.
 type PrometheusWrapper struct {
 	cmd    *exec.Cmd
 	stdout os.File
@@ -16,13 +16,13 @@ type PrometheusWrapper struct {
 }
 
 func NewPrometheusWrapper() (*PrometheusWrapper, error) {
-	return nil, errors.New("Not Implemented")
+	return nil, nil
 }
 
 func (pw *PrometheusWrapper) Start() error {
-	return errors.New("Not Implemented")
+	return nil
 }
 
 func (pw *PrometheusWrapper) Stop() error {
-	return errors.New("Not Implemented")
+	return nil
 }

--- a/Companion/prometheus/wrapper_windows.go
+++ b/Companion/prometheus/wrapper_windows.go
@@ -1,4 +1,5 @@
 //go:build windows
+// +build windows
 
 package prometheus
 

--- a/Companion/realtime_map/map_server.go
+++ b/Companion/realtime_map/map_server.go
@@ -37,7 +37,8 @@ func NewMapServer() (*MapServer, error) {
 
 func (ms *MapServer) Start() {
 	go func() {
-		log.Fatal(ms.httpServer.ListenAndServe())
+		ms.httpServer.ListenAndServe()
+		log.Println("stopping map server")
 	}()
 }
 

--- a/map/src/index.ts
+++ b/map/src/index.ts
@@ -4,6 +4,7 @@ function init()
 {
     let location = window.location
     let params = new URLSearchParams(location.search);
+    let frmHost = "localhost"
     let frmPort = 8080;
 
     if(params.has("frmport")) {
@@ -12,9 +13,15 @@ function init()
             frmPort = p
         }
     }
+    if(params.has("frmhost")) {
+        let h = params.get("frmhost");
+        if(h != undefined){
+            frmHost = h
+        }
+    }
 
     let map = new GameMap(document.getElementById("map")!);
-    map.plotBuildings(`http://localhost:${frmPort}/getFactory`);
-    map.plotTrains(`http://localhost:${frmPort}/getTrains`);
+    map.plotBuildings(`http://${frmHost}:${frmPort}/getFactory`);
+    map.plotTrains(`http://${frmHost}:${frmPort}/getTrains`);
 }
 init();


### PR DESCRIPTION
Supersedes #16 (commit included in this)

Add stats for /getTrains /getVehicles and /getDroneStation. Expose these to
prometheus.

Add extra metrics for trains and vehicles to mark elapsed time between:
* Travel time between stations
* Round trip time for trains
* Round trip time for vehicles

refactor: centralize collector start+stop logic.

collectors should just deal with collecting. leave start and stop to another
object. Allows for simpler adding of collectors.