### PR TITLE
FIX: get consumption and production capacity from raw values

### DIFF
--- a/Companion/exporter/production_collector.go
+++ b/Companion/exporter/production_collector.go
@@ -2,78 +2,20 @@ package exporter
 
 import (
 	"log"
-	"regexp"
-	"strconv"
 )
 
 type ProductionCollector struct {
 	FRMAddress string
 }
 
-var prodPerMinRegex = regexp.MustCompile(`P: (?P<prod_current>[\d.]+)/(?P<prod_capacity>[\d.]+)/min - C: (?P<cons_current>[\d.]+)/(?P<cons_capacity>[\d.]+)/min`)
-
 type ProductionDetails struct {
 	ItemName           string   `json:"ItemName"`
-	ProdPerMin         string   `json:"ProdPerMin"`
-	ProdPercent        *float64 `json:"ProdPercent"`
-	ConsPercent        *float64 `json:"ConsPercent"`
+	ProdPercent        float64 `json:"ProdPercent"`
+	ConsPercent        float64 `json:"ConsPercent"`
 	CurrentProduction  float64  `json:"CurrentProd"`
 	CurrentConsumption float64  `json:"CurrentConsumed"`
 	MaxProd            float64  `json:"MaxProd"`
 	MaxConsumed        float64  `json:"MaxConsumed"`
-}
-
-func (pd *ProductionDetails) parseProdPerMin() (bool, map[string]string) {
-	match := prodPerMinRegex.FindStringSubmatch(pd.ProdPerMin)
-
-	if len(match) < 1 {
-		return false, nil
-	}
-
-	paramsMap := make(map[string]string)
-	for i, name := range prodPerMinRegex.SubexpNames() {
-		if i > 0 && i <= len(match) {
-			paramsMap[name] = match[i]
-		}
-	}
-
-	return true, paramsMap
-}
-
-func (pd *ProductionDetails) ItemProductionCapacity() *float64 {
-	hasMatched, params := pd.parseProdPerMin()
-
-	if !hasMatched {
-		return nil
-	}
-
-	value := params["prod_capacity"]
-
-	v, err := strconv.ParseFloat(value, 64)
-
-	if err != nil {
-		return nil
-	}
-
-	return &v
-}
-
-func (pd *ProductionDetails) ItemConsumptionCapacity() *float64 {
-	hasMatched, params := pd.parseProdPerMin()
-
-	if !hasMatched {
-		return nil
-	}
-
-	value := params["cons_capacity"]
-
-	v, err := strconv.ParseFloat(value, 64)
-
-	if err != nil {
-		return nil
-	}
-
-	return &v
 }
 
 func NewProductionCollector(frmAddress string) *ProductionCollector {
@@ -94,18 +36,9 @@ func (c *ProductionCollector) Collect() {
 		ItemsProducedPerMin.WithLabelValues(d.ItemName).Set(d.CurrentProduction)
 		ItemsConsumedPerMin.WithLabelValues(d.ItemName).Set(d.CurrentConsumption)
 
-		ItemProductionCapacityPercent.WithLabelValues(d.ItemName).Set(*d.ProdPercent)
-		ItemConsumptionCapacityPercent.WithLabelValues(d.ItemName).Set(*d.ConsPercent)
-
-		prodCapacity := d.ItemProductionCapacity()
-		consCapacity := d.ItemConsumptionCapacity()
-
-		if prodCapacity != nil {
-			ItemProductionCapacityPerMinute.WithLabelValues(d.ItemName).Set(*prodCapacity)
-		}
-
-		if consCapacity != nil {
-			ItemConsumptionCapacityPerMinute.WithLabelValues(d.ItemName).Set(*consCapacity)
-		}
+		ItemProductionCapacityPercent.WithLabelValues(d.ItemName).Set(d.ProdPercent)
+		ItemConsumptionCapacityPercent.WithLabelValues(d.ItemName).Set(d.ConsPercent)
+		ItemProductionCapacityPerMinute.WithLabelValues(d.ItemName).Set(d.MaxProd)
+		ItemConsumptionCapacityPerMinute.WithLabelValues(d.ItemName).Set(d.MaxConsumed)
 	}
 }

--- a/Companion/exporter/production_collector_test.go
+++ b/Companion/exporter/production_collector_test.go
@@ -1,21 +1,10 @@
 package exporter_test
 
 import (
-	"fmt"
-
 	"github.com/AP-Hunt/FicsitRemoteMonitoringCompanion/m/v2/exporter"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
-
-func prodPerMin(prodActual float32, prodCapacity float32, consActual float32, consCapacity float32) string {
-	return fmt.Sprintf("P: %f/%f/min - C: %f/%f/min", prodActual, prodCapacity, consActual, consCapacity)
-}
-
-func prodPerMinWithoutCapacity(prodActual float32, consActual float32) string {
-	// Inconsistent spacing in format string is correct according to the API
-	return fmt.Sprintf("P:%f/min - C: %f/min", prodActual, consActual)
-}
 
 var _ = Describe("ProductionCollector", func() {
 	var collector *exporter.ProductionCollector
@@ -27,9 +16,8 @@ var _ = Describe("ProductionCollector", func() {
 		FRMServer.ReturnsProductionData([]exporter.ProductionDetails{
 			{
 				ItemName:           "Iron Rod",
-				ProdPerMin:         prodPerMin(10, 100, 40, 200),
-				ProdPercent:        f(0.1),
-				ConsPercent:        f(0.2),
+				ProdPercent:        0.1,
+				ConsPercent:        0.2,
 				CurrentProduction:  10,
 				CurrentConsumption: 40,
 				MaxProd:            100.0,
@@ -95,38 +83,5 @@ var _ = Describe("ProductionCollector", func() {
 			Expect(val).To(Equal(float64(200)))
 		})
 
-		Describe("when capacity metrics aren't supplied", func() {
-
-			BeforeEach(func() {
-				FRMServer.ReturnsProductionData([]exporter.ProductionDetails{
-					{
-						ItemName:           "Iron Rod",
-						ProdPerMin:         prodPerMinWithoutCapacity(10, 40),
-						ProdPercent:        f(1.0),
-						ConsPercent:        f(1.0),
-						CurrentProduction:  10,
-						CurrentConsumption: 40,
-						MaxProd:            100.0,
-						MaxConsumed:        200.0,
-					},
-				})
-			})
-
-			It("sets 'item_production_capacity_per_min' to zero", func() {
-				collector.Collect()
-
-				val, err := gaugeValue(exporter.ItemProductionCapacityPerMinute, "Iron Rod")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(val).To(Equal(float64(0)))
-			})
-
-			It("sets 'item_consumption_capacity_per_min' to zero", func() {
-				collector.Collect()
-
-				val, err := gaugeValue(exporter.ItemConsumptionCapacityPerMinute, "Iron Rod")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(val).To(Equal(float64(0)))
-			})
-		})
 	})
 })


### PR DESCRIPTION
ProdPerMin values seem to have updated in the latest versions of FRM -- however we do now have reliable MaxProd and MaxConsumed values that capture the production/consumption capacities now. Use those instead, and stop parsing ProdPerMin values.

Simplifies a few things by removing the more complicated parsing logic, and gets things working again