### PR TITLE
refactor: update workflows

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,36 +18,15 @@ jobs:
             exit 1
           fi
   test:
-    defaults:
-      run:
-        shell: powershell
-    name: test
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          node-version: '16'
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '^1.17'
-
-      - name: Install dependencies
-        run: |
-          cd Companion
-          go mod vendor
-
-      - name: Build
-        shell: sh
-        run: |
-          cd Companion
-          make
-
+          go-version: ">=1.22.0"
       - name: Test Companion
-        run: |
-          cd Companion
-          make test
-
+        working-directory: ./Companion
+        run: go test ./...
       - name: Test README generation
-        run: |
-          make readme
+        working-directory: ./Companion
+        run: go run main.go -GenerateReadme > ../README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,58 +6,63 @@
 # so that it doesn't get in to an endless loop
 # when a tagged commit gets pushed.
 on:
-    push:
-        tags:
-            # Tags that look like a semantic version
-            - "[0-9]+.[0-9]+.[0-9]+*"
-defaults:
-  run:
-    shell: powershell
+  push:
+    tags:
+      # Tags that look like a semantic version
+      - "[0-9]+.[0-9]+.[0-9]+*"
 name: Release new version
 jobs:
-    increment_minor_version:
-        name: Increment minor version
-        runs-on: windows-latest
-        steps:
-            - uses: actions/checkout@v2
-              with:
-                fetch-depth: 0
+  increment_minor_version:
+    env:
+      FRMC_VERSION: ${{ github.ref_name }}
+      GOOS: windows
+      GOARCH: amd64
+      PROMETHEUS_VERSION: 2.27.1
+      ZIP_FILENAME: FicsitRemoteMonitoringCompanion-v${{ github.ref_name }}
+    name: Increment minor version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '16'
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.22.0'
+      - name: Compile go release
+        working-directory: ./Companion
+        run: |
+          mkdir ${ZIP_FILENAME}
+          go build -ldflags="-X 'main.Version=${FRMC_VERSION}'" -o ${ZIP_FILENAME}/Companion.exe main.go
+      - name: download prometheus
+        working-directory: ./Companion/${{env.ZIP_FILENAME}}
+        run: |
+          curl -s -o prometheus.tar.gz -L https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.windows-amd64.tar.gz
+          tar -zxvf prometheus.tar.gz
+          mv prometheus-${PROMETHEUS_VERSION}.windows-amd64 prometheus
+          mv ../prometheus.yml ./prometheus/prometheus.yml
+          rm prometheus.tar.gz
+      - name: build map
+        working-directory: ./map
+        run: |
+          npm install
+          npm run compile
+          mkdir -p ../Companion/${ZIP_FILENAME}/map/
+          cp -Rf index.html map-16k.png vendor img js ../Companion/${ZIP_FILENAME}/map/
+      - name: Bundle release
+        working-directory: ./Companion
+        run: |
+          zip -9 -y -r -q FicsitRemoteMonitoringCompanion-v${FRMC_VERSION}.zip ./${ZIP_FILENAME}
+      - name: Generate release notes
+        run: |
+          curl -s -o git-chglog.tar.gz -L https://github.com/git-chglog/git-chglog/releases/download/v0.15.4/git-chglog_0.15.4_linux_amd64.tar.gz
+          tar -zxvf git-chglog.tar.gz git-chglog
+          ./git-chglog -c "./.chglog/config.yml" -t "./.chglog/CHANGELOG.tpl.md" -o "Changelog.md" "${FRMC_VERSION}..${FRMC_VERSION}"
+          cat Changelog.md InstallationInstructions.md > ReleaseNotes.md
 
-            - uses: actions/setup-node@v2
-              with:
-                node-version: '16'
-            - uses: actions/setup-go@v2
-              with:
-                go-version: '^1.17'
-
-            - name: Set version
-              run: |
-                echo "NEW_VERSION=$(cat version.txt)" >> $env:GITHUB_ENV 
-
-            - name: Compile release
-              run: |
-                cd Companion
-                make release
-
-            - name: Generate release notes
-              run: |
-                make release-notes
-
-            - name: Create release
-              id: create_release
-              uses: actions/create-release@v1
-              env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                tag_name: ${{ env.NEW_VERSION }}
-                release_name: "Version ${{ env.NEW_VERSION }}"
-                draft: false
-                prerelease: false
-                body_path: ReleaseNotes.md
-
-            - name: Upload assets
-              id: upload_assets
-              env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                gh release upload "${{ env.NEW_VERSION }}" "./Companion/FicsitRemoteMonitoringCompanion-v${{env.NEW_VERSION}}.zip"
+      - name: Upload assets
+        id: upload_assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${FRMC_VERSION}" --notes-file ReleaseNotes.md "./Companion/FicsitRemoteMonitoringCompanion-v${FRMC_VERSION}.zip"


### PR DESCRIPTION
Update github workflows so we can compile using ubuntu only, no windows. Removes dependencies on windows-only makefiles from github actions

Greatly increases speed of PR and release builds
PR: 4 minutes -> 20 seconds
Release builds 10 minutes -> 1 minute

Remove abandoned actions/create-release
Update action versions