### PR TITLE
exporter: add global resource sink metrics

### DIFF
--- a/Companion/exporter/exporter.go
+++ b/Companion/exporter/exporter.go
@@ -38,7 +38,7 @@ func NewPrometheusExporter(frmApiHosts []string) *PrometheusExporter {
 		vehicleStationCollector := NewVehicleStationCollector("/getTruckStation")
 		trainCollector := NewTrainCollector("/getTrains")
 		trainStationCollector := NewTrainStationCollector("/getTrainStation")
-		resourceSinkCollector := NewResourceSinkCollector("/getResourceSinkBuilding")
+		resourceSinkCollector := NewResourceSinkCollector("/getResourceSinkBuilding", "/getResourceSink")
 		pumpCollector := NewPumpCollector("/getPump")
 		extractorCollector := NewExtractorCollector("/getExtractor")
 		portalCollector := NewPortalCollector("/getPortal")

--- a/Companion/exporter/frm_server_fake_test.go
+++ b/Companion/exporter/frm_server_fake_test.go
@@ -9,22 +9,23 @@ import (
 )
 
 type FRMServerFake struct {
-	server             *httptest.Server
-	productionData     []exporter.ProductionDetails
-	powerData          []exporter.PowerDetails
-	factoryBuildings   []exporter.BuildingDetail
-	vehicleData        []exporter.VehicleDetails
-	trainData          []exporter.TrainDetails
-	droneData          []exporter.DroneStationDetails
-	vehicleStationData []exporter.VehicleStationDetails
-	trainStationData   []exporter.TrainStationDetails
-	resourceSinkData   []exporter.ResourceSinkDetails
-	sessionInfoData    exporter.SessionInfo
-	pumpData           []exporter.PumpDetails
-	extractorData      []exporter.ExtractorDetails
-	portalData         []exporter.PortalDetails
-	hypertubeData      []exporter.HypertubeDetails
-	frackingData       []exporter.FrackingDetails
+	server                *httptest.Server
+	productionData        []exporter.ProductionDetails
+	powerData             []exporter.PowerDetails
+	factoryBuildings      []exporter.BuildingDetail
+	vehicleData           []exporter.VehicleDetails
+	trainData             []exporter.TrainDetails
+	droneData             []exporter.DroneStationDetails
+	vehicleStationData    []exporter.VehicleStationDetails
+	trainStationData      []exporter.TrainStationDetails
+	resourceSinkData      []exporter.ResourceSinkDetails
+	gloalResourceSinkData []exporter.ResourceSinkGlobalDetails
+	sessionInfoData       exporter.SessionInfo
+	pumpData              []exporter.PumpDetails
+	extractorData         []exporter.ExtractorDetails
+	portalData            []exporter.PortalDetails
+	hypertubeData         []exporter.HypertubeDetails
+	frackingData          []exporter.FrackingDetails
 }
 
 func NewFRMServerFake() *FRMServerFake {
@@ -43,6 +44,7 @@ func NewFRMServerFake() *FRMServerFake {
 	mux.Handle("/getVehicles", http.HandlerFunc(getStatsHandler(&fake.vehicleData)))
 	mux.Handle("/getTruckStation", http.HandlerFunc(getStatsHandler(&fake.vehicleStationData)))
 	mux.Handle("/getTrainStation", http.HandlerFunc(getStatsHandler(&fake.trainStationData)))
+	mux.Handle("/getResourceSink", http.HandlerFunc(getStatsHandler(&fake.gloalResourceSinkData)))
 	mux.Handle("/getResourceSinkBuilding", http.HandlerFunc(getStatsHandler(&fake.resourceSinkData)))
 	mux.Handle("/getSessionInfo", http.HandlerFunc(getStatsHandler(&fake.sessionInfoData)))
 	mux.Handle("/getPump", http.HandlerFunc(getStatsHandler(&fake.pumpData)))
@@ -102,6 +104,10 @@ func (e *FRMServerFake) ReturnsTrainStationData(data []exporter.TrainStationDeta
 
 func (e *FRMServerFake) ReturnsResourceSinkData(data []exporter.ResourceSinkDetails) {
 	e.resourceSinkData = data
+}
+
+func (e *FRMServerFake) ReturnsGlobalResourceSinkData(data []exporter.ResourceSinkGlobalDetails) {
+	e.gloalResourceSinkData = data
 }
 
 func (e *FRMServerFake) ReturnsPumpData(data []exporter.PumpDetails) {

--- a/Companion/exporter/resource_sink_collector_test.go
+++ b/Companion/exporter/resource_sink_collector_test.go
@@ -14,7 +14,7 @@ var _ = Describe("ResourceSinkCollector", func() {
 	BeforeEach(func() {
 		FRMServer.Reset()
 		url = FRMServer.server.URL
-		collector = exporter.NewResourceSinkCollector("/getResourceSinkBuilding")
+		collector = exporter.NewResourceSinkCollector("/getResourceSinkBuilding", "/getResourceSink")
 
 		FRMServer.ReturnsResourceSinkData([]exporter.ResourceSinkDetails{
 			{
@@ -39,6 +39,14 @@ var _ = Describe("ResourceSinkCollector", func() {
 				},
 			},
 		})
+
+		FRMServer.ReturnsGlobalResourceSinkData([]exporter.ResourceSinkGlobalDetails{
+			{
+				TotalPoints:    100,
+				PointsToCoupon: 200,
+				NumCoupon:      1,
+			},
+		})
 	})
 
 	AfterEach(func() {
@@ -61,6 +69,33 @@ var _ = Describe("ResourceSinkCollector", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(val).To(Equal(90.0))
+		})
+	})
+
+	Describe("Resource sink global metrics collection", func() {
+		It("sets the 'resource_sink_total_points' metric with the right labels", func() {
+			collector.Collect(url, sessionName)
+
+			val, err := gaugeValue(exporter.ResourceSinkTotalPoints, url, sessionName)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(100.0))
+		})
+		It("sets the 'resource_sink_points_to_coupon' metric with the right labels", func() {
+			collector.Collect(url, sessionName)
+
+			val, err := gaugeValue(exporter.ResourceSinkPointsToCoupon, url, sessionName)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(200.0))
+		})
+		It("sets the 'resource_sink_collected_coupons' metric with the right labels", func() {
+			collector.Collect(url, sessionName)
+
+			val, err := gaugeValue(exporter.ResourceSinkCollectedCoupons, url, sessionName)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(1.0))
 		})
 	})
 })

--- a/Companion/exporter/resource_sink_metrics.go
+++ b/Companion/exporter/resource_sink_metrics.go
@@ -18,4 +18,19 @@ var (
 	}, []string{
 		"circuit_id",
 	})
+
+	ResourceSinkTotalPoints = RegisterNewGaugeVec(prometheus.GaugeOpts{
+		Name: "resource_sink_total_points",
+		Help: "AWESOME sink total points",
+	}, []string{})
+
+	ResourceSinkPointsToCoupon = RegisterNewGaugeVec(prometheus.GaugeOpts{
+		Name: "resource_sink_points_to_coupon",
+		Help: "AWESOME sink points to next coupon",
+	}, []string{})
+
+	ResourceSinkCollectedCoupons = RegisterNewGaugeVec(prometheus.GaugeOpts{
+		Name: "resource_sink_collected_coupons",
+		Help: "AWESOME sink collected coupons",
+	}, []string{})
 )

--- a/Companion/go.mod
+++ b/Companion/go.mod
@@ -1,8 +1,6 @@
 module github.com/AP-Hunt/FicsitRemoteMonitoringCompanion/Companion
 
-go 1.22.0
-
-toolchain go1.23.0
+go 1.23.4
 
 require (
 	github.com/coder/quartz v0.1.2


### PR DESCRIPTION
FRM exposes the amount of coupons and points via `/getResourceSink` and allows to monitor the total amount of points per minute with `rate`.